### PR TITLE
fix: 避免证书日志污染 TLS 解析结果

### DIFF
--- a/lib/mihomo/core.sh
+++ b/lib/mihomo/core.sh
@@ -161,7 +161,7 @@ _mh_resolve_tls() {
     local domain="$1" name="$2" fake_sni="$3"
     if [[ -n "$domain" ]]; then
         source "$LIB_DIR/cert.sh"
-        if cert_ensure_domain "$domain" 2>/dev/null; then
+        if cert_ensure_domain "$domain" >&2; then
             local d="$NGINX_SSL_DIR/$domain"
             if [[ -s "$d/fullchain.pem" && -s "$d/privkey.pem" ]]; then
                 printf '%s\t%s\t%s\t0\n' "$d/fullchain.pem" "$d/privkey.pem" "$domain"

--- a/lib/singbox/core.sh
+++ b/lib/singbox/core.sh
@@ -172,7 +172,7 @@ _sb_resolve_tls() {
     local domain="$1" name="$2" fake_sni="$3"
     if [[ -n "$domain" ]]; then
         source "$LIB_DIR/cert.sh"
-        if cert_ensure_domain "$domain" 2>/dev/null; then
+        if cert_ensure_domain "$domain" >&2; then
             local d="$NGINX_SSL_DIR/$domain"
             if [[ -s "$d/fullchain.pem" && -s "$d/privkey.pem" ]]; then
                 printf '%s\t%s\t%s\t0\n' "$d/fullchain.pem" "$d/privkey.pem" "$domain"


### PR DESCRIPTION
修复 Issue #1。

根因：TLS helper 通过命令替换读取四字段元数据时，cert_ensure_domain 同时把证书状态日志写入 stdout。read 因而读到日志首行，insecure 变为空值，最终触发 jq --argjson 报错。

本 PR 仅将 sing-box 与 mihomo 两个共享 TLS helper 中的证书交互输出重定向到 stderr，保证 stdout 只包含可解析的 TSV 元数据；不增加其他功能。该修复同时覆盖两内核共用 helper 的 AnyTLS 与 Hysteria2 流程。

已验证 Bash 语法、git diff --check，并使用已有域名证书场景确认两套 helper 均返回 example.com 和 insecure=0，jq --argjson 可正常解析。

Fixes #1